### PR TITLE
Introducing optionally vendored build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ links = "nfc"
 
 [features]
 vendored = []
+drivers = []
 logging = ["vendored"]
 conffiles = ["vendored"]
 envvars = ["vendored"]
-default = ["vendored"]
+default = ["vendored", "drivers"]
 
 [dependencies]
 libusb1-sys = { version = "0.5", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ links = "nfc"
 
 [features]
 vendored = []
+logging = ["vendored"]
+conffiles = ["vendored"]
+envvars = ["vendored"]
 default = ["vendored"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 edition = "2018"
 links = "nfc"
 
+[features]
+vendored = []
+default = ["vendored"]
+
 [dependencies]
 libusb1-sys = { version = "0.5", features = ["vendored"] }
 usb-compat-01-sys = "0.2"
@@ -17,6 +21,10 @@ usb-compat-01-sys = "0.2"
 cc = "1.0"
 cmake = "0.1"
 bindgen = "0.58"
+pkg-config = "0.3"
+
+[target.'cfg(target_env = "msvc")'.build-dependencies]
+vcpkg = "0.2"
 
 [lib]
 crate-type = ["rlib", "staticlib"]

--- a/build.rs
+++ b/build.rs
@@ -8,6 +8,16 @@ use std::path::PathBuf;
 
 static VERSION: &'static str = "1.8.0";
 
+macro_rules! on_by_feature {
+	($f: literal) => {
+		if cfg!(feature = $f) {
+			"ON"
+		} else {
+			"OFF"
+		}
+	}
+}
+
 fn make_source(nfc_dir: &PathBuf, out_dir: &PathBuf) -> Package {
 	let usb01_include_dir = PathBuf::from(env::var("DEP_USB_0.1_INCLUDE").expect("usb-compat-01-sys did not export DEP_USB_0.1_INCLUDE"));
 	let usb1_include_dir = PathBuf::from(env::var("DEP_USB_1.0_INCLUDE").expect("libusb1-sys did not export DEP_USB_1.0_INCLUDE"));
@@ -28,9 +38,9 @@ fn make_source(nfc_dir: &PathBuf, out_dir: &PathBuf) -> Package {
 	config.define("CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE", &build_dir);
 	config.define("CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE", &build_dir);
 	config.define("CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE", &build_dir);
-	config.define("LIBNFC_LOG", "OFF");
-	config.define("LIBNFC_CONFFILES_MODE", "OFF");
-	config.define("LIBNFC_ENVVARS", "OFF");
+	config.define("LIBNFC_LOG", on_by_feature!("logging"));
+	config.define("LIBNFC_CONFFILES_MODE", on_by_feature!("conffiles"));
+	config.define("LIBNFC_ENVVARS", on_by_feature!("envvars"));
 	config.out_dir(&out_dir);
 
 	if std::env::var("CARGO_CFG_TARGET_OS") == Ok("windows".into()) {

--- a/build.rs
+++ b/build.rs
@@ -117,7 +117,6 @@ fn main() {
 	let vendor_dir = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR var not set")).join("vendor");
 	let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR var not set"));
 	let nfc_dir = vendor_dir.join("nfc");
-	let libnfc_dir = nfc_dir.join("libnfc");
 	let libnfc_pkg = if cfg!(feature = "vendored") {
 		make_source(&nfc_dir, &out_dir)
 	} else {
@@ -140,42 +139,48 @@ fn main() {
 	}
 
 	// Generate libnfc bindings
-	let bindings = Builder::default()
-		.clang_arg(format!("-I{}", libnfc_dir.display()))
+	bindings = bindings
 		.allowlist_function("iso14443[ab]_.*")
 		.allowlist_function("str_nfc_.*")
 		.allowlist_function("nfc_.*")
 		.allowlist_type("nfc_.*")
-		.allowlist_var("NFC_.*")
-		.header(libnfc_dir.join("iso7816.h").to_str().unwrap())
-		.allowlist_var("ISO7816_.*")
-		.header(libnfc_dir.join("drivers").join("acr122_pcsc.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("acr122_usb.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("acr122s.h").to_str().unwrap())
-		.allowlist_function("acr122s?_.*")
-		.allowlist_type("acr122s?_.*")
-		.allowlist_var("ACR122S?_.*")
-		.header(libnfc_dir.join("drivers").join("arygon.h").to_str().unwrap())
-		.allowlist_function("arygon_.*")
-		.allowlist_type("arygon_.*")
-		.allowlist_var("ARYGON_.*")
-		.header(libnfc_dir.join("chips").join("pn53x.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("pn53x_usb.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("pn532_i2c.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("pn532_spi.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("pn532_uart.h").to_str().unwrap())
-		.header(libnfc_dir.join("drivers").join("pn71xx.h").to_str().unwrap())
-		.allowlist_function("pn(53[x23]|71xx)_.*")
-		.allowlist_type("pn(53[x23]|71xx)_.*")
-		.allowlist_var("PN(53[Xx23]|71XX)_.*")
-		.header(libnfc_dir.join("drivers").join("pcsc.h").to_str().unwrap())
-		.allowlist_function("pcsc_.*")
-		.allowlist_type("pcsc_.*")
-		.allowlist_var("PCSC_.*")
-		.generate()
-		.expect("Unable to generate nfc bindings");
+		.allowlist_var("NFC_.*");
+
+	if cfg!(feature = "drivers") {
+		let libnfc_dir = nfc_dir.join("libnfc");
+
+		bindings = bindings
+			.clang_arg(format!("-I{}", libnfc_dir.display()))
+			.header(libnfc_dir.join("iso7816.h").to_str().unwrap())
+			.allowlist_var("ISO7816_.*")
+			.header(libnfc_dir.join("drivers").join("acr122_pcsc.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("acr122_usb.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("acr122s.h").to_str().unwrap())
+			.allowlist_function("acr122s?_.*")
+			.allowlist_type("acr122s?_.*")
+			.allowlist_var("ACR122S?_.*")
+			.header(libnfc_dir.join("drivers").join("arygon.h").to_str().unwrap())
+			.allowlist_function("arygon_.*")
+			.allowlist_type("arygon_.*")
+			.allowlist_var("ARYGON_.*")
+			.header(libnfc_dir.join("chips").join("pn53x.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("pn53x_usb.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("pn532_i2c.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("pn532_spi.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("pn532_uart.h").to_str().unwrap())
+			.header(libnfc_dir.join("drivers").join("pn71xx.h").to_str().unwrap())
+			.allowlist_function("pn(53[x23]|71xx)_.*")
+			.allowlist_type("pn(53[x23]|71xx)_.*")
+			.allowlist_var("PN(53[Xx23]|71XX)_.*")
+			.header(libnfc_dir.join("drivers").join("pcsc.h").to_str().unwrap())
+			.allowlist_function("pcsc_.*")
+			.allowlist_type("pcsc_.*")
+			.allowlist_var("PCSC_.*");
+	}
 
 	bindings
+		.generate()
+		.expect("Unable to generate nfc bindings")
 		.write_to_file(out_dir.join("bindings.rs"))
 		.expect("Unable to write nfc bindings");
 }


### PR DESCRIPTION
This crate uses the vendored libnfc by default, disabling logging, config files, and environment vars features. This is useful especially for Windows-like platforms. However, in GNU-like platforms, that is standard to use shared libraries instead of the vendored one.

This pull request proposes to introduce "optionally" vendored build by `vendored` feature, which is enabled by default. That means this changes do not break any backward compatibilities using default features.

Additionally I added some features to turn on/off functionalities of the vendored libnfc.
Features are described below:

|Feature|Default?|Description|
|---|---|---|
|vendored|**Yes**|Use vendored libnfc, instead of installed one on the platform.|
|drivers|**Yes**|Add chip or driver specific symbols from vendored libnfc.|
|logging|No|Enables logging when using the vendored libnfc.|
|conffiles|No|Enables config files on vendored libnfc.|
|envvars|No|Enables environment variables on vendored libnfc.|

Thank you for creating this create ツ