### PR TITLE
Add support for forcing pkg-config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ links = "nfc"
 
 [features]
 vendored = ["libusb1-sys/vendored", "usb-compat-01-sys", "cmake"]
+force-pkg-config = []
 drivers = []
 logging = ["vendored"]
 usb_logging = ["vendored", "usb-compat-01-sys/logging"]

--- a/build.rs
+++ b/build.rs
@@ -236,7 +236,7 @@ struct Package {
     include_paths: Vec<PathBuf>,
 }
 
-#[cfg(all(target_env = "msvc", not(feature = "vendored")))]
+#[cfg(all(target_env = "msvc", not(feature = "force-pkg-config"), not(feature = "vendored")))]
 fn find_libnfc_pkg(_is_static: bool) -> Option<Package> {
     match vcpkg::Config::new().find_package("libnfc") {
         Ok(l) => Some(Package {
@@ -249,7 +249,7 @@ fn find_libnfc_pkg(_is_static: bool) -> Option<Package> {
     }
 }
 
-#[cfg(all(not(target_env = "msvc"), not(feature = "vendored")))]
+#[cfg(all(any(not(target_env = "msvc"), feature = "force-pkg-config"), not(feature = "vendored")))]
 fn find_libnfc_pkg(is_static: bool) -> Option<Package> {
     match pkg_config::Config::new().statik(is_static).probe("libnfc") {
         Ok(l) => {


### PR DESCRIPTION
This workarounds the situation where MSVC compatible libraries are available from a (MSYS2 provided) CLANG64 environment, and as such can be resolved using `pkg-config`.

I'm however not sure if this is the right way to solve the issue...

The instructions I used for building libnfc on CLANG64 can be found [here](https://gitlab.com/ikspress/nfc-toolkit) (should work for other MSYS2 envs too).